### PR TITLE
Dynamically determine the set of attendee or folder tags to preserve

### DIFF
--- a/main.js
+++ b/main.js
@@ -1605,8 +1605,8 @@ class GranolaSyncPlugin extends obsidian.Plugin {
 			await this.app.fileManager.processFrontMatter(file, (frontmatter) => {
 				// Preserve existing tags that are not person or folder tags
 				const existingTags = frontmatter.tags || [];
-				const preservedTags = existingTags.filter(tag => 
-					attendeeTags.includes(tag) || folderTags.includes(tag)
+				const preservedTags = existingTags.filter(
+				    (tag) => !attendeeTags.includes(tag) && !folderTags.includes(tag)
 				);
 				
 				// Combine attendee and folder tags


### PR DESCRIPTION
I found that my tags were being duplicated every run because I use an overridden attendee tag prefix.

This change makes the process for determining which tags to preserve dynamic.

I think it's possible that a setting to decide if you want tags to be preserved to begin with may be warranted