### PR TITLE
fix: search subfolders when detecting duplicates in sync directory

### DIFF
--- a/main.js
+++ b/main.js
@@ -825,12 +825,13 @@ class GranolaSyncPlugin extends obsidian.Plugin {
 				}
 			}
 		} else {
-			// Default: search only in sync directory
+			// Default: search only in sync directory (including subfolders)
 			const folder = this.app.vault.getFolderByPath(this.settings.syncDirectory);
 			if (!folder) {
 				return null;
 			}
-			filesToSearch = folder.children.filter(file => file instanceof obsidian.TFile && file.extension === 'md');
+			// Use recursive search to find notes in subfolders (important for date-based or Granola folder organization)
+			filesToSearch = this.getAllMarkdownFilesInFolder(folder);
 		}
 		
 		for (const file of filesToSearch) {


### PR DESCRIPTION
## Problem

When using date-based folders or Granola folder organization, notes are stored in subfolders of the sync directory. The duplicate detection (`findExistingNoteByGranolaId`) was only searching direct children of the sync directory using `folder.children.filter()`, missing notes in subfolders.

This caused duplicates to be created when:
- Filename patterns were changed (the note with old name exists but wasn't found)
- Notes were organized into subfolders

## Solution

Use `getAllMarkdownFilesInFolder()` for the sync directory search scope, which recursively finds all markdown files including those in subfolders. This is already used for the "specific folders" search scope.

## Testing

1. Enable date-based folders or Granola folders
2. Sync notes (they go into subfolders)
3. Change filename pattern
4. Sync again
5. Notes should be updated in place, not duplicated

## Version

Patch bump recommended: 1.9.0 → 1.9.1

## Closes

- #34