### PR TITLE
fix: support nested Granola folders in folder-based path generation

### DIFF
--- a/main.js
+++ b/main.js
@@ -283,9 +283,12 @@ class GranolaSyncPlugin extends obsidian.Plugin {
 				if (folders) {
 					// Create a mapping of document ID to folder for quick lookup
 					this.documentToFolderMap = {};
+					// Create a mapping of folder ID to folder for parent traversal
+					this.folderIdMap = {};
 					// Also store all available folders for the settings UI
 					this.availableGranolaFolders = folders;
 					for (const folder of folders) {
+						this.folderIdMap[folder.id] = folder;
 						if (folder.document_ids) {
 							for (const docId of folder.document_ids) {
 								this.documentToFolderMap[docId] = folder;
@@ -760,13 +763,24 @@ class GranolaSyncPlugin extends obsidian.Plugin {
 			return this.settings.syncDirectory;
 		}
 
-		// Clean folder name for filesystem use
-		const cleanFolderName = folder.title
+		// Build the full folder path by traversing parent_document_list_id chain
+		const cleanName = (title) => title
 			.replace(/[<>:"/\\|?*]/g, '') // Remove invalid filesystem characters
 			.replace(/\s+/g, this.settings.filenameSeparator) // Replace spaces with configured separator
 			.trim();
 
-		return path.join(this.settings.syncDirectory, cleanFolderName);
+		const segments = [];
+		let current = folder;
+		const visited = new Set();
+		while (current) {
+			if (visited.has(current.id)) break; // guard against cycles
+			visited.add(current.id);
+			segments.unshift(cleanName(current.title));
+			const parentId = current.parent_document_list_id;
+			current = (parentId && this.folderIdMap) ? this.folderIdMap[parentId] : null;
+		}
+
+		return path.join(this.settings.syncDirectory, ...segments);
 	}
 
 	async ensureDateBasedDirectoryExists(datePath) {
@@ -2006,7 +2020,10 @@ class GranolaSyncPlugin extends obsidian.Plugin {
 					if (folders) {
 						// Create a mapping of document ID to folder for quick lookup
 						this.documentToFolderMap = {};
+						// Create a mapping of folder ID to folder for parent traversal
+						this.folderIdMap = {};
 						for (const folder of folders) {
+							this.folderIdMap[folder.id] = folder;
 							if (folder.document_ids) {
 								for (const docId of folder.document_ids) {
 									this.documentToFolderMap[docId] = folder;


### PR DESCRIPTION
  ## Summary

  - Adds a `folderIdMap` (folder ID → folder object) when building folder mappings at sync time
  - Updates `generateFolderBasedPath` to walk the `parent_document_list_id` chain, building the full nested path instead of always placing folders at the root of the sync directory
  - Applies the configured `filenameSeparator` consistently to all path segments, including parent folder names

  ## Problem

Granola supports nested spaces. Previously, only the direct folder name was used — the parent folder was silently dropped, so all sub-spaces were placed flat at the sync directory root.

  ## Test plan

  - [ ] Enable "Granola Folders" in plugin settings
  - [ ] Verify that meetings in a nested space sync to `<syncDir>/ParentSpace/ChildSpace/note.md`
  - [ ] Verify top-level spaces still sync to `<syncDir>/SpaceName/note.md`
  - [ ] Verify meetings with no space still sync to `<syncDir>/note.md`
  - [ ] Test with a non-default `filenameSeparator` — folder names should use it too