### PR TITLE
Add option to hide per-speaker timestamps in transcripts

### DIFF
--- a/main.js
+++ b/main.js
@@ -42,6 +42,7 @@ const DEFAULT_SETTINGS = {
 	syncAllHistoricalNotes: false, // Sync all historical notes from Granola, not just recent ones
 	documentSyncLimit: 100, // Maximum number of documents to sync (used when syncAllHistoricalNotes is false)
 	includeFullTranscript: false, // Include full meeting transcript in notes
+	includeTranscriptTimestamps: true, // Include timestamps next to each speaker in transcript
 	includeMyNotes: true, // Include "My Notes" section from Granola
 	includeEnhancedNotes: true, // Include "Enhanced Notes" (AI summary) from Granola
 	selectedGranolaFolders: [], // Array of Granola folder IDs to sync (empty = sync all)
@@ -230,9 +231,13 @@ class GranolaSyncPlugin extends obsidian.Plugin {
 		const flushCurrentSegment = () => {
 			const cleanText = currentText.trim().replace(/\s+/g, " ");
 			if (cleanText && currentSpeaker) {
-				const timeStr = this.formatTimestamp(currentTimestamp);
 				const speakerLabel = this.getSpeakerLabel(currentSpeaker);
-				lines.push(`**${speakerLabel}** *(${timeStr})*: ${cleanText}`)
+				if (this.settings.includeTranscriptTimestamps) {
+					const timeStr = this.formatTimestamp(currentTimestamp);
+					lines.push(`**${speakerLabel}** *(${timeStr})*: ${cleanText}`);
+				} else {
+					lines.push(`**${speakerLabel}**: ${cleanText}`);
+				}
 			}
 			currentText = "";
 			currentSpeaker = null;
@@ -2175,8 +2180,23 @@ class GranolaSyncSettingTab extends obsidian.PluginSettingTab {
 				toggle.onChange(async (value) => {
 					this.plugin.settings.includeFullTranscript = value;
 					await this.plugin.saveSettings();
+					this.display(); // Refresh to show/hide timestamp setting
 				});
 			});
+
+		// Show transcript timestamps toggle only when full transcript is enabled
+		if (this.plugin.settings.includeFullTranscript) {
+			new obsidian.Setting(containerEl)
+				.setName('Include transcript timestamps')
+				.setDesc('Show timestamps (HH:MM:SS) next to each speaker in the transcript.')
+				.addToggle(toggle => {
+					toggle.setValue(this.plugin.settings.includeTranscriptTimestamps);
+					toggle.onChange(async (value) => {
+						this.plugin.settings.includeTranscriptTimestamps = value;
+						await this.plugin.saveSettings();
+					});
+				});
+		}
 
 		// Create a heading for filename settings
 		containerEl.createEl('h3', {text: 'Filename settings'});


### PR DESCRIPTION
When using the full transcript feature, each speaker turn includes an `HH:MM:SS` timestamp. For some workflows (e.g. feeding notes into LLMs or just keeping notes leaner) these timestamps aren't useful and add bulk.

This adds an **Include transcript timestamps** toggle that lets users disable the per-speaker timestamps while keeping the full transcript content. When turned off, lines render as `**Speaker**: text` instead of `**Speaker** *(HH:MM:SS)*: text`.

### Details

- New setting `includeTranscriptTimestamps`, defaults to `true` (no change for existing users)
- The toggle only appears in settings when "Include full transcript" is enabled, matching the existing pattern for dependent settings (e.g. `syncAllHistoricalNotes` / `documentSyncLimit`)
- `formatTimestamp()` is only called when timestamps are enabled