### PR TITLE
Add optional attendee backlinks in frontmatter

### DIFF
--- a/main.js
+++ b/main.js
@@ -31,6 +31,8 @@ const DEFAULT_SETTINGS = {
 	includeFolderTags: false,
 	includeGranolaUrl: false,
 	attendeeTagTemplate: 'person/{name}',
+	includeAttendeeBacklinks: false, // Write attendee names as Obsidian wikilinks in frontmatter
+	attendeeBacklinkProperty: 'participants', // Frontmatter property name for attendee backlinks
 	existingNoteSearchScope: 'syncDirectory', // 'syncDirectory', 'entireVault', 'specificFolders'
 	specificSearchFolders: [], // Array of folder paths to search in when existingNoteSearchScope is 'specificFolders'
 	enableDateBasedFolders: false,
@@ -1194,7 +1196,7 @@ class GranolaSyncPlugin extends obsidian.Plugin {
 				const allTags = [...attendeeTags, ...folderTags];
 
 				// Build frontmatter using centralized helper
-				const frontmatter = this.buildFrontmatter(doc, title, allTags, granolaUrl);
+				const frontmatter = this.buildFrontmatter(doc, title, allTags, granolaUrl, attendeeNames);
 
 				// Build the note content with all sections
 				const noteContent = this.buildNoteContent(doc, transcript);
@@ -1224,7 +1226,7 @@ class GranolaSyncPlugin extends obsidian.Plugin {
 		const allTags = [...attendeeTags, ...folderTags];
 
 		// Build frontmatter using centralized helper
-		const frontmatter = this.buildFrontmatter(doc, title, allTags, granolaUrl);
+		const frontmatter = this.buildFrontmatter(doc, title, allTags, granolaUrl, attendeeNames);
 
 		// Build the note content with all sections
 		const noteContent = this.buildNoteContent(doc, transcript);
@@ -1671,6 +1673,30 @@ class GranolaSyncPlugin extends obsidian.Plugin {
 		return tags;
 	}
 
+	generateAttendeeBacklinks(attendees) {
+		if (!this.settings.includeAttendeeBacklinks || !attendees || attendees.length === 0) {
+			return [];
+		}
+
+		const backlinks = [];
+
+		for (const attendee of attendees) {
+			// Apply the same "my name" exclusion as attendee tags
+			if (this.settings.excludeMyNameFromTags && this.settings.myName &&
+				attendee.toLowerCase().trim() === this.settings.myName.toLowerCase().trim()) {
+				continue;
+			}
+
+			const link = '[[' + attendee.trim() + ']]';
+
+			if (!backlinks.includes(link)) {
+				backlinks.push(link);
+			}
+		}
+
+		return backlinks;
+	}
+
 	extractFolderNames(doc) {
 		const folderNames = [];
 		
@@ -1852,7 +1878,7 @@ class GranolaSyncPlugin extends obsidian.Plugin {
 	 * @param {string} granolaUrl - Granola URL (or null)
 	 * @returns {string} - Complete frontmatter string with delimiters
 	 */
-	buildFrontmatter(doc, title, allTags, granolaUrl) {
+	buildFrontmatter(doc, title, allTags, granolaUrl, attendeeNames = []) {
 		const docId = doc.id;
 		let frontmatter = '---\n';
 		
@@ -1887,7 +1913,17 @@ class GranolaSyncPlugin extends obsidian.Plugin {
 				frontmatter += '  - ' + tag + '\n';
 			}
 		}
-		
+
+		// Attendee backlinks (optional wikilinks in a separate frontmatter property)
+		const attendeeBacklinks = this.generateAttendeeBacklinks(attendeeNames);
+		if (attendeeBacklinks.length > 0) {
+			const prop = this.settings.attendeeBacklinkProperty || 'participants';
+			frontmatter += prop + ':\n';
+			for (const link of attendeeBacklinks) {
+				frontmatter += '  - "' + link + '"\n';
+			}
+		}
+
 		// Additional custom frontmatter
 		const additionalFm = this.parseAdditionalFrontmatter();
 		if (additionalFm) {
@@ -1928,6 +1964,8 @@ class GranolaSyncPlugin extends obsidian.Plugin {
 			const folderTags = this.generateFolderTags(folderNames);
 			const granolaUrl = this.generateGranolaUrl(doc.id);
 
+			const attendeeBacklinks = this.generateAttendeeBacklinks(attendeeNames);
+
 			// Use FileManager.processFrontMatter for atomic frontmatter updates
 			await this.app.fileManager.processFrontMatter(file, (frontmatter) => {
 				// Preserve existing tags that are not person or folder tags
@@ -1941,6 +1979,12 @@ class GranolaSyncPlugin extends obsidian.Plugin {
 
 				// Update tags
 				frontmatter.tags = [...preservedTags, ...newTags];
+
+				// Update or add attendee backlinks if enabled
+				if (attendeeBacklinks.length > 0) {
+					const prop = this.settings.attendeeBacklinkProperty || 'participants';
+					frontmatter[prop] = attendeeBacklinks;
+				}
 
 				// Update or add Granola URL if enabled
 				if (granolaUrl) {
@@ -2515,6 +2559,29 @@ class GranolaSyncSettingTab extends obsidian.PluginSettingTab {
 						new obsidian.Notice('Warning: Tag template should include {name} placeholder');
 					}
 					this.plugin.settings.attendeeTagTemplate = value || 'person/{name}';
+					await this.plugin.saveSettings();
+				});
+			});
+
+		new obsidian.Setting(containerEl)
+			.setName('Include attendee backlinks')
+			.setDesc('Add meeting attendees as Obsidian wikilinks in a separate frontmatter property (e.g. participants: ["[[Eddie Brock]]"])')
+			.addToggle(toggle => {
+				toggle.setValue(this.plugin.settings.includeAttendeeBacklinks);
+				toggle.onChange(async (value) => {
+					this.plugin.settings.includeAttendeeBacklinks = value;
+					await this.plugin.saveSettings();
+				});
+			});
+
+		new obsidian.Setting(containerEl)
+			.setName('Attendee backlink property')
+			.setDesc('Frontmatter property name used for attendee wikilinks (default: participants)')
+			.addText(text => {
+				text.setPlaceholder('participants');
+				text.setValue(this.plugin.settings.attendeeBacklinkProperty);
+				text.onChange(async (value) => {
+					this.plugin.settings.attendeeBacklinkProperty = value || 'participants';
 					await this.plugin.saveSettings();
 				});
 			});

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,7 @@ An Obsidian plugin that automatically syncs your [Granola AI](https://granola.ai
 - **🗓️ Daily Note Integration**: Automatically add today's meetings to your Daily Note with times and links
 - **📅 Periodic Notes Support**: Full integration with the Periodic Notes plugin for flexible daily note management
 - **🏷️ Attendee Tagging**: Automatically extract meeting attendees and add them as organized tags (e.g., `person/john-smith`)
+- **🔗 Attendee Backlinks**: Optionally write attendees as Obsidian wikilinks (e.g., `[[Eddie Brock]]`) in a configurable frontmatter property
 - **🔗 Granola URL Links**: Add direct links back to original Granola notes in frontmatter for easy access
 - **🔧 Smart Filtering**: Exclude your own name from attendee tags with configurable settings
 - **🛡️ Preserve Manual Additions**: Option to skip updating existing notes, preserving your tags, summaries, and custom properties
@@ -122,6 +123,36 @@ Automatically extract meeting attendees from Granola and add them as organized t
 - **Clean organization**: All attendee tags grouped under `person/` prefix
 - **Smart filtering**: Your name is automatically excluded from tags
 - **Retroactive updates**: Can update existing notes with attendee tags while preserving content
+
+### Attendee Backlinks
+
+Optionally write meeting attendees as Obsidian wikilinks in a separate frontmatter property. This is additive — existing attendee tags are always preserved unchanged.
+
+#### Settings:
+- **Include Attendee Backlinks**: Enable/disable wikilink generation (disabled by default)
+- **Attendee Backlink Property**: The frontmatter property name to use (default: `participants`)
+
+#### How it works:
+When enabled, each synced note gains a new frontmatter property containing `[[Name]]` wikilinks for every attendee (using the same "exclude my name" filter as tags):
+
+```yaml
+---
+tags:
+  - person/eddie-brock
+  - person/gwen-stacy
+participants:
+  - "[[Eddie Brock]]"
+  - "[[Gwen Stacy]]"
+---
+```
+
+The attendee display name is used exactly as it appears in Granola — no normalization or aliasing is applied.
+
+#### Benefits:
+- **Graph view connections**: Attendees appear as linked nodes in Obsidian's graph view
+- **Backlink panel**: Navigate directly to people pages from each meeting note
+- **Additive**: Tags are never removed or altered; backlinks sit alongside them
+- **Configurable property**: Rename the property to fit your vault's schema (e.g., `people`, `attendees`)
 
 ### Granola URL Integration
 


### PR DESCRIPTION
## Summary

- Adds an optional setting to write meeting attendees as Obsidian wikilinks in a configurable frontmatter property (default: `participants`)
- Existing attendee tag behaviour is completely unchanged — backlinks are purely additive
- Two new settings: **Include attendee backlinks** (toggle, off by default) and **Attendee backlink property** (text field, default `participants`)

## New Settings

| Setting | Type | Default | Description |
|---|---|---|---|
| Include attendee backlinks | Toggle | Off | Write attendees as `[[wikilinks]]` in frontmatter |
| Attendee backlink property | Text | `participants` | Frontmatter property name for the wikilinks |

## Before / After

**Before** (tags only, unchanged):
```yaml
tags:
  - person/eddie-brock
  - person/gwen-stacy
```

**After** (tags preserved + backlinks added when enabled):
```yaml
tags:
  - person/eddie-brock
  - person/gwen-stacy
participants:
  - "[[Eddie Brock]]"
  - "[[Gwen Stacy]]"
```

## Notes

- The existing "Exclude my name from tags" setting also applies to backlinks
- Duplicates are removed
- Works for both new notes and existing note metadata updates
- Property name is fully configurable (e.g. `people`, `attendees`, `contacts`)