### PR TITLE
Fix 401 auth error after Granola migrated to encrypted storage / stored-accounts.json

### DIFF
--- a/main.js
+++ b/main.js
@@ -392,7 +392,13 @@ class GranolaSyncPlugin extends obsidian.Plugin {
 			// Current configured path
 			path.resolve(homedir, this.settings.authKeyPath),
 			// Fallback to old default location
-			path.resolve(homedir, 'Library/Application Support/Granola/supabase.json')
+			path.resolve(homedir, 'Library/Application Support/Granola/supabase.json'),
+			// May 2026: Granola migrated to encrypted on-disk storage; tokens now live in stored-accounts.json
+			...(obsidian.Platform.isWin
+				? [path.resolve(homedir, 'AppData/Roaming/Granola/stored-accounts.json')]
+				: obsidian.Platform.isLinux
+					? [path.resolve(homedir, '.config/Granola/stored-accounts.json')]
+					: [path.resolve(homedir, 'Library/Application Support/Granola/stored-accounts.json')])
 		];
 
 		for (const authPath of authPaths) {
@@ -427,7 +433,21 @@ class GranolaSyncPlugin extends obsidian.Plugin {
 						accessToken = data.cognito_tokens.access_token;
 					}
 				}
-				
+
+				// May 2026 multi-account format (stored-accounts.json):
+				// { accounts: "[{ tokens: \"{access_token,refresh_token,...}\", userInfo, ... }]" }
+				if (!accessToken && data.accounts) {
+					try {
+						const accounts = typeof data.accounts === 'string' ? JSON.parse(data.accounts) : data.accounts;
+						if (Array.isArray(accounts) && accounts.length > 0 && accounts[0].tokens) {
+							const tokens = typeof accounts[0].tokens === 'string' ? JSON.parse(accounts[0].tokens) : accounts[0].tokens;
+							accessToken = tokens && tokens.access_token;
+						}
+					} catch (e) {
+						console.error('Error parsing stored-accounts.json accounts:', e);
+					}
+				}
+
 				if (accessToken) {
 					console.log('Successfully loaded credentials from:', authPath);
 					return accessToken;


### PR DESCRIPTION
Granola updated their on-disk storage format (visible in Granola desktop app builds from late April / early May 2026). The plugin currently fails with `401 Unauthorized` because it can no longer find a valid token.

## What changed on Granola's side

In `~/Library/Application Support/Granola/`:

| Old (plaintext) | New |
|---|---|
| `supabase.json` | `supabase.json.enc` (encrypted, key in `storage.dek`) |
| `cache-v6.json` | `cache-v6.json.enc` |
| `user-preferences.json` | `user-preferences.json.enc` |
| — | `stored-accounts.json` (NEW — multi-account-aware, plaintext) |

`supabase.json` is no longer written at all. Auth tokens now live in `stored-accounts.json` under a new shape:

```json
{
  "accounts": "[{\"userId\":\"...\",\"email\":\"...\",\"tokens\":\"{\\\"access_token\\\":\\\"...\\\",\\\"refresh_token\\\":\\\"...\\\",\\\"expires_in\\\":21599,...}\",\"userInfo\":\"...\",\"savedAt\":...}]"
}
```

(Note the double-stringification — `accounts` is a stringified JSON array, and each `tokens` field inside it is also a stringified JSON object.)

The token issuer also changed to `https://auth.granola.ai/user_management/...` (WorkOS-based, `CrossAppAuth` sign-in method).

## What this PR changes

`loadCredentials()` now:

1. Tries `stored-accounts.json` as an additional fallback path after the existing `supabase.json` paths (platform-appropriate paths for macOS, Windows, and Linux).
2. Adds a parsing branch for the new `accounts[].tokens.access_token` shape (existing `workos_tokens` and `cognito_tokens` branches are kept untouched for backwards compat with users who haven't upgraded the Granola desktop app yet).

## Verified

Patched my local installed copy and confirmed:
- Token extraction works against a real `stored-accounts.json`
- Sync runs successfully and pulls new notes from the API
- Existing `supabase.json` paths still work as a higher-priority fallback (so users on older Granola builds are unaffected)