### PR TITLE
fix: sync My Notes from doc.notes for manually-created notes

### DIFF
--- a/main.js
+++ b/main.js
@@ -1279,6 +1279,12 @@ class GranolaSyncPlugin extends obsidian.Plugin {
 			return doc.content;
 		}
 
+		// Fallback: for my_notes, check doc.notes (used for manually-created notes
+		// and notes without a recording — see issue #33 scottxp comment).
+		if (panelType === 'my_notes' && doc.notes && doc.notes.type === 'doc') {
+			return doc.notes;
+		}
+
 		return null;
 	}
 


### PR DESCRIPTION
## Summary

- Adds a `doc.notes` fallback to `extractPanelContent` for the `my_notes` panel type
- Mirrors the existing `doc.content` fallback shape (`type === 'doc'` check), so no downstream conversion changes are needed

## Problem

`extractPanelContent` currently checks `doc.panels[]` then falls back to `doc.content`. For manually-created notes (Quick Notes, or notes without a recording), Granola returns the user's typed content in a top-level `doc.notes` field instead — neither location the extractor inspects. Result: the synced file has title/metadata and an empty `## Transcript` section, but the `## My Notes` section is omitted and the typed body is silently dropped.

@scottxp first identified this in #33 ("To get the `my_notes` panel to sync, I had to use `doc.notes` rather than `doc.content`"), but the v1.9.2 fix only added the `doc.content` fallback, which covers a different shape.

Filed as #62.

## Test plan

- [x] Create a Granola note manually (no recording) with typed content
- [x] Run sync — verify `## My Notes` appears in the resulting `.md` with the typed body
- [x] Re-sync an existing note that already had a working `## My Notes` (recorded meeting) — verify nothing regresses
- [x] Re-sync a note whose `my_notes` content lives in `doc.panels[]` (typical meeting case) — verify it still uses the panels path, not the new fallback