### PR TITLE
Stop tagging meeting rooms and group aliases as people

### DIFF
--- a/main.js
+++ b/main.js
@@ -99,6 +99,19 @@ function readGranolaKeychainPasswordMac() {
 const API_KEY_KEYCHAIN_SERVICE = 'granola-sync-plus';
 const API_KEY_KEYCHAIN_ACCOUNT = 'granola-api-key';
 
+// Calendar invitees that are not people: meeting rooms, projectors, and other
+// bookable resources. Google flags them with resource: true and addresses them
+// on *.calendar.google.com (e.g. c_1885...@resource.calendar.google.com).
+// Without this they become attendee tags such as person/c-1885....
+const NON_PERSON_EMAIL_DOMAIN = /@[^@]*\.calendar\.google\.com$/i;
+
+function isNonPersonAttendee(attendee) {
+	if (!attendee) return true;
+	if (attendee.resource === true) return true;
+	if (attendee.email && NON_PERSON_EMAIL_DOMAIN.test(attendee.email)) return true;
+	return false;
+}
+
 function storeApiKeyInKeychainMac(apiKey) {
 	try {
 		const { execFileSync } = require('child_process');
@@ -1086,7 +1099,14 @@ class GranolaSyncPlugin extends obsidian.Plugin {
 			doc.people = note.attendees.map(a => ({ name: a.name, email: a.email }));
 		}
 
-		if (note.calendar_event && Array.isArray(note.calendar_event.invitees)) {
+		// The invitee list is only a fallback source of attendee names. When the
+		// note carries its own attendees, those are the people who were actually
+		// in the meeting and they come with real display names; the invitee list
+		// additionally contains group aliases (team-foo@example.com) and rooms,
+		// which have no names and would be tagged as person/team-foo. Only fall
+		// back to invitees when there are no attendees to work from.
+		const hasAttendees = doc.people.length > 0;
+		if (!hasAttendees && note.calendar_event && Array.isArray(note.calendar_event.invitees)) {
 			doc.google_calendar_event = {
 				attendees: note.calendar_event.invitees.map(invitee => {
 					if (typeof invitee === 'string') return { email: invitee };
@@ -1298,8 +1318,13 @@ class GranolaSyncPlugin extends obsidian.Plugin {
 
 	generateNoteTitle(doc) {
 		const title = doc.title || 'Untitled Granola Note';
-		// Clean the title for use as a heading - remove invalid characters but keep spaces
-		return title.replace(/[<>:"/\\|?*]/g, '').trim();
+		// Clean the title for use as a heading - remove invalid characters but keep spaces.
+		// Stripping a character can leave a gap ("Shir / Ming" -> "Shir  Ming"), so
+		// collapse runs of whitespace afterwards.
+		return title
+			.replace(/[<>:"/\\|?*]/g, '')
+			.replace(/\s+/g, ' ')
+			.trim();
 	}
 
 	generateFilename(doc) {
@@ -2246,7 +2271,18 @@ class GranolaSyncPlugin extends obsidian.Plugin {
 					if (attendee.email && processedEmails.has(attendee.email)) {
 						continue;
 					}
-					
+
+					// Skip meeting rooms, equipment, and other non-human invitees.
+					// Google marks these with resource: true, and their addresses
+					// live on *.calendar.google.com, so they would otherwise be
+					// turned into person tags like person/c-18856jur41crmik6gsea.
+					if (isNonPersonAttendee(attendee)) {
+						if (attendee.email) {
+							processedEmails.add(attendee.email);
+						}
+						continue;
+					}
+
 					if (attendee.displayName && !attendees.includes(attendee.displayName)) {
 						attendees.push(attendee.displayName);
 						if (attendee.email) {


### PR DESCRIPTION
Two small attendee/title bugs, both pre-dating the API auth mode from #67. `main.js` only — I left `CHANGELOG.md` alone since #63 and #68 did the same and you write the entries at release prep. There's a summary at the bottom you can lift if it's useful.

## 1. Non-human invitees become person tags

Calendar invitee lists carry bookable resources and group addresses next to real attendees, and `extractAttendeeNames` had no notion that either is not a person. Neither has a display name, so it fell through to the email localpart:

```yaml
tags:
  - person/c-18856jur41crmik6gseagvjq5ocde   # a conference room
  - person/team-api-core                      # a distribution list
```

These land permanently in the vault's tag namespace and show up in the tag pane and Dataview queries.

**This is not a regression from #67**, though that's how it looks, so it's worth being precise:

- **Group aliases behave identically in both auth modes, and always have.** A group address has no display name either way, so both paths use the localpart. In my vault these tags run continuously from 2025-10-30 through the last local-mode sync.
- **Rooms were already being tagged in local mode, just legibly.** Google supplies a real `displayName` for room resources, so local mode produced wrong-but-readable tags like `person/london-office-4th-hyde-park-6-tv-zoom`. The official API's `calendar_event.invitees` carry `name: null`, so the same rooms fall through to the opaque localpart instead. API mode converted readable garbage into unreadable garbage, which is what made me finally notice it.

The fallback itself dates to `2dedea6` (attendee tagging, v1.2.0).

### Fix

- Skip non-human invitees outright, keyed on Google's `resource: true` flag or any `*.calendar.google.com` address (`isNonPersonAttendee`). Applies to both auth modes, so this should also stop the readable room tags local mode has been emitting since v1.2.0.
- In API mode, demote the invitee list to a fallback: when a note carries its own `attendees`, those are the people who were actually in the meeting and they arrive with real names, so invitees are only consulted when there are no attendees at all. This is what handles group aliases, without guessing from localparts.

## 2. Stripped characters leave a gap in the heading

`generateNoteTitle` removes filesystem-invalid characters but never re-collapses whitespace, so a note titled `Shir / Ming` renders as `# Shir  Ming`. `generateFilename` already collapses via `filenameSeparator`; this brings the heading in line.

## Verification

Ran the changed functions against four real synced notes on this branch (i.e. on top of current `main`, including #68). Before → after:

| Note | Before | After |
|---|---|---|
| `Shir / Ming` | `# Shir  Ming` | `# Shir Ming` |
| `API Core 2x2` | + `person/c-18856jur41crmik6gseagvjq5ocde` | 3 real attendees only |
| `API Core Standup` | + `person/c-1885…`, `person/team-api-core` | 9 real attendees only |
| `DeepL All Hands` | no change | no change |

Unit checks on the filter: `*@resource.calendar.google.com` and `*@group.calendar.google.com` are skipped, `resource: true` is honoured, and ordinary addresses pass through (including `team-api-core@deepl.com`, which the attendees-authoritative path handles rather than the domain filter).

Local-mode verification is the gap I can't close: Granola 7.427+ killed local-token auth on my machine, so the local-mode half of the room claim rests on the invitee carrying its resource email or flag, which is what Google sends, rather than on an end-to-end run. Worth a second pair of eyes if you still have a working local setup.

## Behaviour change worth calling out

Invited-but-absent people are no longer tagged in API mode, because the attendees list now drives tagging. I think that's the correct reading of "who was in this meeting", but it is a change in output for anyone relying on invitee-derived tags. Happy to put it behind a setting if you'd rather not change the default.

The plugin also won't retroactively clean tags it previously wrote; existing notes need a separate pass.

## Changelog summary, if useful

> **Meeting rooms and group aliases no longer become attendee tags**: Calendar invitee lists include bookable resources (`c_1885…@resource.calendar.google.com`) and group addresses (`team-api-core@example.com`) alongside real people. Having no display name, these fell through to the email localpart and produced tags like `person/c-1885jur41crmik6gseagvjq5ocde` and `person/team-api-core`. Non-human invitees are now skipped (Google's `resource: true` flag, or any `*.calendar.google.com` address). In API mode the invitee list is also demoted to a fallback, consulted only when a note has no attendees of its own, since attendees carry real names.
>
> **Headings no longer keep a gap where a character was stripped**: A title containing a filesystem-invalid character produced a double space in the H1, e.g. `Shir / Ming` became `# Shir  Ming`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Calendar invitees such as rooms, resources and calendar service addresses are now excluded from attendee lists.
  - Notes no longer duplicate or incorrectly include non-person invitee email addresses.
  - Calendar-based note adaptation now uses invitee details only when attendee records are unavailable.
  - Note titles now maintain clean spacing when unsupported characters are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->